### PR TITLE
Enhance CAI store functionality and update supported types

### DIFF
--- a/.cursor/rules/c2pa-pec.mdc
+++ b/.cursor/rules/c2pa-pec.mdc
@@ -1,0 +1,340 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# C2PA and Media Format Specialization Guidelines
+
+## C2PA Specification Expertise
+
+### Core Concepts
+1. **Claims and Manifests**
+   - Follow [C2PA Specification v2.1](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html)
+   - Implement claim generation and validation
+   - Handle manifest embedding and extraction
+   - Support claim redaction and updates
+
+2. **Assertions**
+   - Implement standard C2PA assertions
+   - Support custom assertion types
+   - Handle assertion validation
+   - Manage assertion relationships
+
+3. **Signatures and Validation**
+   - COSE Sign1 structure implementation
+   - Certificate chain validation
+   - Time stamp authority integration
+   - Hash verification
+
+### Implementation Patterns
+
+#### Claim Structure
+```rust
+pub struct Claim {
+    // External manifest handling
+    remote_manifest: RemoteManifest,
+    update_manifest: bool,
+
+    // Core claim fields
+    pub title: Option<String>,
+    pub format: Option<String>,
+    pub instance_id: String,
+    pub claim_generator: Option<String>,
+    pub claim_generator_info: Option<Vec<ClaimGeneratorInfo>>,
+
+    // Assertions and signatures
+    signature_val: Vec<u8>,
+    assertion_store: Vec<ClaimAssertion>,
+    assertions: Vec<C2PAAssertion>,
+    created_assertions: Vec<C2PAAssertion>,
+    gathered_assertions: Option<Vec<C2PAAssertion>>,
+
+    // Ingredients and data
+    ingredients_store: HashMap<String, Vec<Claim>>,
+    data_boxes: Vec<(HashedUri, DataBox)>,
+
+    // Version and algorithm info
+    claim_version: usize,
+    alg: Option<String>,
+    alg_soft: Option<String>,
+}
+```
+
+#### Assertion Handling
+```rust
+pub struct ClaimAssertion {
+    assertion: Assertion,
+    instance: usize,
+    hash_val: Vec<u8>,
+    hash_alg: String,
+    salt: Option<Vec<u8>>,
+    typ: ClaimAssertionType,
+}
+
+impl ClaimAssertion {
+    pub fn new(
+        assertion: Assertion,
+        instance: usize,
+        hashval: &[u8],
+        alg: &str,
+        salt: Option<Vec<u8>>,
+        typ: ClaimAssertionType,
+    ) -> ClaimAssertion {
+        ClaimAssertion {
+            assertion,
+            instance,
+            hash_val: hashval.to_vec(),
+            hash_alg: alg.to_string(),
+            salt,
+            typ,
+        }
+    }
+}
+```
+
+#### Remote Manifest Handling
+```rust
+pub enum RemoteManifest {
+    NoRemote,                // No external manifest
+    SideCar,                 // Side car file
+    Remote(String),          // Remote reference
+    EmbedWithRemote(String), // Embedded with remote reference
+}
+```
+
+## Media Format Specialization
+
+### DASH (Dynamic Adaptive Streaming over HTTP)
+1. **MPD (Media Presentation Description)**
+   - Segment template handling
+   - Adaptation set management
+   - Period and representation structure
+   - Content protection integration
+
+2. **Segment Formats**
+   - ISO Base Media File Format (BMFF)
+   - CMAF (Common Media Application Format)
+   - Initialization segment handling
+   - Media segment processing
+
+### BMFF (ISO Base Media File Format)
+1. **Box Structure**
+   - File type box (ftyp)
+   - Movie box (moov)
+   - Media data box (mdat)
+   - Track box (trak)
+
+2. **Implementation Patterns**
+```rust
+// BMFF Box Structure
+pub struct Box {
+    pub size: u32,
+    pub box_type: [u8; 4],
+    pub data: Vec<u8>,
+}
+
+// Track Structure
+pub struct Track {
+    pub track_id: u32,
+    pub media_type: MediaType,
+    pub timescale: u32,
+    pub duration: u64,
+    pub samples: Vec<Sample>,
+}
+```
+
+### CMAF (Common Media Application Format)
+1. **VOD (Video on Demand)**
+   - Segment alignment
+   - Track selection
+   - Initialization segment
+   - Media segment structure
+
+2. **Live Streaming**
+   - Segment timing
+   - Playlist management
+   - Live window handling
+   - Segment availability
+
+### MBR (Multiple Bitrate)
+1. **Adaptation Logic**
+   - Bandwidth estimation
+   - Quality switching
+   - Buffer management
+   - Segment selection
+
+2. **Implementation Patterns**
+```rust
+// Adaptation Set Structure
+pub struct AdaptationSet {
+    pub id: String,
+    pub mime_type: String,
+    pub representations: Vec<Representation>,
+    pub segment_alignment: bool,
+}
+
+// Representation Structure
+pub struct Representation {
+    pub id: String,
+    pub bandwidth: u32,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub codecs: String,
+    pub initialization: String,
+    pub media: String,
+}
+```
+
+## Integration Guidelines
+
+### C2PA with Media Formats
+1. **Manifest Embedding**
+   - Box structure preservation
+   - Signature placement
+   - Hash calculation
+   - Validation integration
+
+2. **Streaming Considerations**
+   - Live manifest updates
+   - Segment validation
+   - Time stamp synchronization
+   - Bandwidth impact
+
+### Implementation Examples
+
+#### C2PA Manifest in BMFF
+```rust
+pub struct C2paBox {
+    pub size: u32,
+    pub box_type: [u8; 4], // 'c2pa'
+    pub manifest: Manifest,
+    pub signature: Signature,
+}
+
+// DASH with C2PA
+pub struct C2paAdaptationSet {
+    pub adaptation_set: AdaptationSet,
+    pub manifest: Option<Manifest>,
+    pub validation_status: ValidationStatus,
+}
+```
+
+#### Claim Generation
+```rust
+impl Claim {
+    pub fn new<S: Into<String>>(
+        claim_generator: S,
+        vendor: Option<&str>,
+        claim_version: usize,
+    ) -> Self {
+        Claim {
+            claim_generator: Some(claim_generator.into()),
+            instance_id: Uuid::new_v4().to_string(),
+            claim_version,
+            ..Default::default()
+        }
+    }
+
+    pub fn add_assertion(
+        &mut self,
+        assertion_builder: &impl AssertionBase,
+    ) -> Result<C2PAAssertion> {
+        self.add_assertion_with_salt(assertion_builder, &NO_SALT)
+    }
+}
+```
+
+#### Validation
+```rust
+impl Claim {
+    pub(crate) async fn verify_claim_async(
+        claim: &Claim,
+        asset_data: &mut ClaimAssetData<'_>,
+        is_provenance: bool,
+        cert_check: bool,
+        ctp: &CertificateTrustPolicy,
+        validation_log: &mut StatusTracker,
+    ) -> Result<()> {
+        // Implementation
+    }
+
+    pub fn verify_hash(&self, hash: &[u8]) -> bool {
+        self.hash() == hash
+    }
+}
+```
+
+## Best Practices
+
+### C2PA Implementation
+1. **Security**
+   - Secure signature generation
+   - Certificate validation
+   - Time stamp verification
+   - Hash integrity checks
+
+2. **Performance**
+   - Efficient manifest parsing
+   - Optimized validation
+   - Memory management
+   - Streaming optimization
+
+### Media Format Handling
+1. **DASH**
+   - MPD validation
+   - Segment alignment
+   - Adaptation logic
+   - Live window management
+
+2. **CMAF**
+   - VOD segment handling
+   - Live streaming support
+   - Track selection
+   - Time synchronization
+
+3. **MBR**
+   - Bandwidth adaptation
+   - Quality switching
+   - Buffer management
+   - Segment selection
+
+## Testing Requirements
+
+### C2PA Validation
+1. **Manifest Testing**
+   - Claim validation
+   - Signature verification
+   - Time stamp checking
+   - Hash verification
+
+2. **Media Format Testing**
+   - Box structure validation
+   - Segment alignment
+   - Stream compatibility
+   - Performance testing
+
+### Integration Testing
+1. **DASH Integration**
+   - MPD generation
+   - Segment handling
+   - Adaptation testing
+   - Live streaming
+
+2. **CMAF Integration**
+   - VOD testing
+   - Live streaming
+   - Track selection
+   - Time synchronization
+
+## References
+
+### C2PA Documentation
+- [C2PA Specification v2.1](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html)
+- [C2PA Technical Specification](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_technical_specification)
+- [C2PA Assertions](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_assertions)
+
+### Media Format Documentation
+- [DASH Specification](https://dashif.org/guidelines/)
+- [CMAF Specification](https://aomediacodec.github.io/cmaf-spec/)
+- [ISO Base Media File Format](https://www.iso.org/standard/68960.html)
+- [MPEG-DASH](https://www.iso.org/standard/65274.html) 

--- a/.cursor/rules/rust.mdc
+++ b/.cursor/rules/rust.mdc
@@ -1,0 +1,279 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Rust Coding Guidelines
+
+## Project Structure
+
+### Module Organization
+```
+sdk/src/
+├── lib.rs              # Public API and module declarations
+├── assertions/         # C2PA assertion implementations
+├── asset_handlers/     # Asset format handlers
+├── utils/             # Utility functions
+├── wasm/              # WebAssembly specific code
+└── [domain].rs        # Core domain implementations
+```
+
+### Module Rules
+1. Public modules should be declared in `lib.rs`
+2. Internal modules should use `pub(crate)` visibility
+3. Group related functionality in subdirectories
+4. Use feature flags for optional functionality
+5. Keep file sizes manageable (prefer < 1000 lines)
+
+### Feature Organization
+```rust
+// In lib.rs
+#[cfg(feature = "feature_name")]
+pub mod feature_module;
+
+// In code
+#[cfg(feature = "feature_name")]
+pub fn feature_function() { ... }
+```
+
+## Code Formatting
+
+### Rustfmt Configuration
+The project uses nightly rustfmt with the following configuration:
+
+```toml
+blank_lines_upper_bound = 1
+edition = "2018"
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+hex_literal_case = "Lower"
+imports_granularity = "Crate"
+reorder_impl_items = true
+unstable_features = true
+```
+
+To format your code:
+```bash
+rustup toolchain add nightly
+cargo +nightly fmt
+```
+
+### Import Organization
+```rust
+// Standard library imports
+use std::path::Path;
+
+// External crate imports
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// Internal crate imports
+use crate::error::Result;
+use crate::utils::hash_utils;
+```
+
+## Error Handling
+
+### Error Type Definition
+```rust
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    // Domain-specific errors
+    #[error("error message: {0}")]
+    DomainError(String),
+
+    // Feature-specific errors
+    #[cfg(feature = "feature_name")]
+    #[error("feature error: {0}")]
+    FeatureError(String),
+
+    // Third-party errors
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+```
+
+### Error Usage
+```rust
+// Prefer
+fn process() -> Result<()> {
+    let data = read_file()?;
+    validate_data(&data)?;
+    Ok(())
+}
+
+// Avoid
+fn process() -> Result<()> {
+    let data = read_file().unwrap();
+    validate_data(&data).expect("validation failed");
+    Ok(())
+}
+```
+
+## Documentation
+
+### Module Documentation
+```rust
+//! Module description
+//!
+//! # Examples
+//!
+//! ```rust
+//! use crate::module::function;
+//! let result = function()?;
+//! ```
+```
+
+### Function Documentation
+```rust
+/// Function description
+///
+/// # Arguments
+///
+/// * `param` - Parameter description
+///
+/// # Returns
+///
+/// Returns `Result<T>` where T is the return type
+///
+/// # Errors
+///
+/// * `Error::Variant` - When something goes wrong
+///
+/// # Examples
+///
+/// ```rust
+/// let result = function(param)?;
+/// ```
+```
+
+## Testing
+
+### Unit Tests
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_function_success() {
+        let result = function("valid input");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_function_error() {
+        let result = function("invalid input");
+        assert!(result.is_err());
+    }
+}
+```
+
+### Integration Tests
+- Place in `tests/` directory
+- Test public API
+- Use test fixtures
+- Test feature-gated functionality
+
+## Performance
+
+### Guidelines
+1. Use appropriate data structures
+2. Avoid unnecessary allocations
+3. Use references when possible
+4. Profile before optimizing
+5. Use `#[inline]` judiciously
+
+### Common Optimizations
+```rust
+// Prefer
+let mut vec = Vec::with_capacity(size);
+
+// Over
+let mut vec = Vec::new();
+```
+
+## Security
+
+### Best Practices
+1. Validate all input data
+2. Use secure random number generators
+3. Handle sensitive data carefully
+4. Follow the principle of least privilege
+5. Use appropriate cryptographic libraries
+
+## Dependencies
+
+### Guidelines
+1. Keep dependencies up to date
+2. Use specific versions in Cargo.toml
+3. Review security advisories
+4. Minimize dependencies
+5. Use feature flags for optional dependencies
+
+## Commit Messages
+
+Follow conventional commits format:
+- `fix`: Bug fixes
+- `feat`: New features
+- `chore`: Maintenance tasks
+- `update`: Updates to existing features
+- `doc`: Documentation changes
+
+Format:
+```
+type(scope): description
+
+[optional body]
+[optional footer]
+```
+
+Example:
+```
+feat(api): add new validation method
+
+Adds support for validating C2PA v2 claims with improved error handling.
+```
+
+## Platform Support
+
+The project supports:
+- x86_64-unknown-linux-gnu
+- x86_64-apple-darwin
+- x86_64-pc-windows-msvc
+- aarch64-apple-darwin
+- wasm32-unknown-unknown
+
+Ensure code works across all supported platforms.
+
+## Code Generation
+
+When generating code, follow these patterns:
+
+1. **Module Structure**:
+   - Place public API in `lib.rs`
+   - Use `pub(crate)` for internal modules
+   - Group related functionality in subdirectories
+
+2. **Error Handling**:
+   - Use `thiserror` for error types
+   - Implement `From` for error conversions
+   - Use `?` operator for error propagation
+
+3. **Feature Flags**:
+   - Gate optional functionality
+   - Document feature requirements
+   - Test feature combinations
+
+4. **Documentation**:
+   - Include examples
+   - Document error conditions
+   - Use markdown formatting
+
+5. **Testing**:
+   - Write unit tests
+   - Include integration tests
+   - Test error cases 

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1036,13 +1036,15 @@ impl BmffHash {
             let c2pa_boxes = read_bmff_c2pa_boxes(&mut seg_reader)?;
             let box_infos = &c2pa_boxes.box_infos;
 
-            if box_infos.iter().filter(|b| b.path == "moof").count() != 1 {
-                return Err(Error::BadParam("expected 1 moof in fragment".to_string()));
-            }
+            // TODO: add support for multiple moofs in a fragment
+            // if box_infos.iter().filter(|b| b.path == "moof").count() != 1 {
+            //     return Err(Error::BadParam("expected 1 moof in fragment".to_string()));
+            // }
 
-            if box_infos.iter().filter(|b| b.path == "mdat").count() != 1 {
-                return Err(Error::BadParam("expected 1 mdat in fragment".to_string()));
-            }
+            // TODO: add support for multiple mdats in a fragment
+            // if box_infos.iter().filter(|b| b.path == "mdat").count() != 1 {
+            //     return Err(Error::BadParam("expected 1 mdat in fragment".to_string()));
+            // }
 
             // we don't currently support adding to fragments with existing manifests
             if !c2pa_boxes.bmff_merkle.is_empty() {

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -65,7 +65,7 @@ const FULL_BOX_TYPES: &[&str; 80] = &[
     "txtC", "mime", "uri ", "uriI", "hmhd", "sthd", "vvhd", "medc",
 ];
 
-static SUPPORTED_TYPES: [&str; 13] = [
+static SUPPORTED_TYPES: [&str; 16] = [
     "avif",
     "heif",
     "heic",
@@ -79,6 +79,9 @@ static SUPPORTED_TYPES: [&str; 13] = [
     "image/heif",
     "video/mp4",
     "video/quicktime",
+    "m4s",
+    "mcfv",
+    "mcfa"
 ];
 
 macro_rules! boxtype {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -906,6 +906,16 @@ impl Store {
 
         for manifest_box in claim.get_box_order() {
             match *manifest_box {
+                CLAIM => {
+                    let mut cb = CAIClaimBox::new(claim.version());
+
+                    // Add the Claim json
+                    let claim_cbor_bytes = claim.data()?;
+                    let c_cbor = JUMBFCBORContentBox::new(claim_cbor_bytes);
+                    cb.add_claim(Box::new(c_cbor));
+
+                    cai_store.add_box(Box::new(cb)); // add claim to manifest
+                }
                 ASSERTIONS => {
                     let mut a_store = CAIAssertionStore::new();
 
@@ -916,16 +926,6 @@ impl Store {
                     }
 
                     cai_store.add_box(Box::new(a_store)); // add the assertion store to the manifest
-                }
-                CLAIM => {
-                    let mut cb = CAIClaimBox::new(claim.version());
-
-                    // Add the Claim json
-                    let claim_cbor_bytes = claim.data()?;
-                    let c_cbor = JUMBFCBORContentBox::new(claim_cbor_bytes);
-                    cb.add_claim(Box::new(c_cbor));
-
-                    cai_store.add_box(Box::new(cb)); // add claim to manifest
                 }
                 SIGNATURE => {
                     // create a signature and add placeholder data to the CAI store.
@@ -1122,8 +1122,8 @@ impl Store {
                 let (box_label, _instance) =
                     Claim::box_name_label_instance(desc_box.label().as_ref());
                 match box_label.as_ref() {
-                    ASSERTIONS => box_order.push(ASSERTIONS),
                     CLAIM => box_order.push(CLAIM),
+                    ASSERTIONS => box_order.push(ASSERTIONS),
                     SIGNATURE => box_order.push(SIGNATURE),
                     CREDENTIALS => box_order.push(CREDENTIALS),
                     DATABOXES => box_order.push(DATABOXES),


### PR DESCRIPTION
- Added functionality to handle CLAIM boxes in the CAI store. They were added in a different order than the order they are read.
- Updated the order of box processing to ensure ASSERTIONS are handled correctly.
- Commented out validation for multiple moof and mdat boxes in BmffHash.
- Expanded the list of supported types in BMFF IO to include m4s, mcfv, and mcfa.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
